### PR TITLE
Deep reorg scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 
 # IDE configuration
 .idea
+
+_bin/

--- a/api/ui_handler.go
+++ b/api/ui_handler.go
@@ -165,6 +165,11 @@ func (h *UIHandler) ReOrg(w http.ResponseWriter, r *http.Request) {
 	h.erigonNode.FindReorgs(r.Context(), w, h.uiTemplate, requestChannel)
 }
 
+func (h *UIHandler) DeepReOrg(w http.ResponseWriter, r *http.Request) {
+	requestChannel := h.uiSessions.LookUpSession(r.FormValue(currentSessionName))
+	h.erigonNode.FindDeepReorgs(r.Context(), w, h.uiTemplate, requestChannel)
+}
+
 func (h *UIHandler) BodiesDownload(w http.ResponseWriter, r *http.Request) {
 	requestChannel := h.uiSessions.LookUpSession(r.FormValue(currentSessionName))
 	h.erigonNode.BodiesDownload(r.Context(), w, h.uiTemplate, requestChannel)
@@ -210,6 +215,7 @@ func NewUIHandler(
 	r.Post("/log_download", r.LogDownload)
 
 	r.Post("/reorgs", r.ReOrg)
+	r.Post("/deepReorgs", r.DeepReOrg)
 	r.Post("/bodies_download", r.BodiesDownload)
 	r.Post("/headers_download", r.HeadersDownload)
 	r.Post("/sync_stages", r.SyncStages)

--- a/assets/script/session.js
+++ b/assets/script/session.js
@@ -174,6 +174,20 @@ async function fetchSession(sessionName, description, sessionPin) {
         })
 }
 
+async function findDeepReorgs(sessionName) {
+    const d = document.getElementById('deepreorgs');
+    d.innerHTML = "Looking for deep reorgs...";
+    let formData = new FormData();
+    formData.append('current_session_name', sessionName);
+    const request =  createRequest("/ui/deepReorgs", "POST", formData)
+    fetch(request)
+        .then((response) => response.body)
+        .then((body) => body.getReader())
+        .then((reader) => processReader(d, reader))
+        .then(() => console.log('completed'))
+        .catch((err) => d.innerHTML = "ERROR: " + err.message);
+}
+
 function createForm(jsonData) {
     let formData = new FormData();
     for (const [key, value] of Object.entries(jsonData)) {

--- a/assets/template/deep_reorg.html
+++ b/assets/template/deep_reorg.html
@@ -1,0 +1,1 @@
+<div class="block">{{.}}</div>

--- a/assets/template/session.html
+++ b/assets/template/session.html
@@ -68,6 +68,10 @@
                         <button type="button" onclick="bodiesDownload('{{.SessionName}}')">Bodies Download</button>
                         <div id="bodies_download"></div>
                     </div>
+                    <div>
+                        <button type="button" onclick="findDeepReorgs('{{.SessionName}}')">Find Deep Reorgs</button>
+                        <div id="deepreorgs"></div>
+                    </div>
                 {{end}}
             </div>
 </form>

--- a/internal/erigon_node/deep_reorg.go
+++ b/internal/erigon_node/deep_reorg.go
@@ -1,0 +1,161 @@
+package erigon_node
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"html/template"
+	"net/http"
+	"time"
+
+	"github.com/ledgerwatch/diagnostics/internal"
+)
+
+type BlockNode struct {
+	Height     uint64
+	Hash       uint64
+	ParentHash uint64
+	Children   []*BlockNode
+}
+
+// Demonstration of the working with the Erigon database remotely on the example of getting information
+// about past reorganisation of the chain
+
+// FindDeepReorgs - Go through "Header" table and look for entries with the same block number and find lenght of deep reorgs on every block
+// by using hash, parent hash, and block number
+func (c *NodeClient) FindDeepReorgs(ctx context.Context,
+	writer http.ResponseWriter,
+	template *template.Template,
+	requestChannel chan *internal.NodeRequest) {
+	start := time.Now()
+	var err error
+
+	rc := NewRemoteCursor(c, requestChannel)
+	if err = rc.Init(headersDb, headersTable, nil); err != nil {
+		fmt.Fprintf(writer, "Create remote cursor: %v", err)
+		return
+	}
+
+	total, wrongBlocks, errors := c.findDeepReorgsInternally(ctx, template, rc)
+	for _, err := range errors {
+		if err != nil {
+			fmt.Fprintf(writer, "%v\n", err)
+		}
+	}
+	fmt.Fprintf(writer, "Reorg iterator: %d, total scanned %s\n", total, time.Since(start))
+	fmt.Fprintf(writer, "Reorg iterator: %d, wrong blocks\n", len(wrongBlocks))
+}
+
+func (c *NodeClient) findDeepReorgsInternally(ctx context.Context,
+	template *template.Template,
+	rc *RemoteCursor,
+) (uint64, map[uint64]map[uint64]uint64, []error) {
+	// mapping to store information of blocks on particular height
+	deepReorgs := make(map[uint64][]*BlockNode)
+	// store key and value fetched from DB
+	var k []byte
+	var v []byte
+	var err error
+	// stores maximum block height in order to find main chain
+	var max uint64 = 0
+	// store block-height, block-hash, and block's parent hash
+	var height, hash, parentHash uint64
+	// mapping to store block information corresponding to their block hash
+	blocks := make(map[uint64]*BlockNode)
+	// bool to avoid adding 1st node as children to a nil node
+	var isFirst = true
+	var countBlocks uint64 = 0
+	// loop to iterate over all blocks as key value pairs and store their info
+	for k, v, err = rc.Next(); err == nil && k != nil; k, v, err = rc.Next() {
+		// fetch block height, hash, and parentHash from key vlaue pair
+		height = binary.BigEndian.Uint64(k[:8])
+		hash = binary.BigEndian.Uint64(k[8:40])
+		parentHash = binary.BigEndian.Uint64(v[4:36])
+
+		// initialize new block info
+		newNode := &BlockNode{
+			Height:     height,
+			Hash:       hash,
+			ParentHash: parentHash,
+			Children:   []*BlockNode{},
+		}
+
+		// map block info corresponding to its hash
+		blocks[hash] = newNode
+
+		// condition to append block info to existing blockInfos according to their block height
+		if _, found := deepReorgs[height]; found {
+			// add block address as its parent's children
+			blocks[newNode.ParentHash].Children = append(blocks[newNode.ParentHash].Children, newNode)
+			deepReorgs[height] = append(deepReorgs[height], newNode)
+		} else {
+			if isFirst {
+				isFirst = false
+			} else {
+				// add block address as its parent's children
+				blocks[newNode.ParentHash].Children = append(blocks[newNode.ParentHash].Children, newNode)
+			}
+			deepReorgs[height] = []*BlockNode{newNode}
+		}
+
+		// helps in finding longest chain
+		if height > max {
+			max = height
+		}
+
+		// increment count of blocks
+		countBlocks++
+	}
+
+	if err != nil {
+		return 0, make(map[uint64]map[uint64]uint64), []error{err}
+	}
+
+	// returns empty mapping when no block info is available
+	if len(blocks) == 0 {
+		return 0, make(map[uint64]map[uint64]uint64), nil
+	}
+
+	// block to iterate over to find main chain
+	var node *BlockNode
+	var found bool = true
+	// mapping to store main block corresponding to its height
+	mainChain := make(map[uint64]*BlockNode)
+	// maps main block according to its height
+	for node = deepReorgs[max][0]; found; node, found = blocks[node.ParentHash] {
+		mainChain[node.Height] = node
+	}
+
+	// mapping to store info for blockHeight of block from which reorgs are originating -> length of reorgs -> number of reorgs of corresponding length
+	allReorgs := make(map[uint64]map[uint64]uint64)
+	for _, node := range mainChain {
+		// only iterate when there is a reorg initiating from that block
+		if len(node.Children) > 1 {
+			// initialize mapping for a particular node height
+			allReorgs[node.Height] = make(map[uint64]uint64)
+			// iterate over child blocks of node with reorg chains
+			for _, block := range node.Children {
+				// only iterate if it is not a part of main chain
+				if mainChain[block.Height].Hash != block.Hash {
+					allReorgs = appendDeepReorgInfo(1, block, allReorgs, node.Height)
+				}
+			}
+		}
+	}
+	return countBlocks, allReorgs, nil
+}
+
+// function to be called upon finding reorgs to store number of reorgs on that height corresponding to that reorg height
+func appendDeepReorgInfo(reorgHeight uint64, node *BlockNode, allReorgs map[uint64]map[uint64]uint64, nodeHeight uint64) map[uint64]map[uint64]uint64 {
+	// reorg count to be incremented only when node is a leaf node
+	if len(node.Children) == 0 {
+		// increment reorg count for that reorg height reorg height
+		allReorgs[nodeHeight][reorgHeight]++
+	} else {
+		// iterate over all other blocks to find reorgs of increased length
+		for _, block := range node.Children {
+			appendDeepReorgInfo(reorgHeight+1, block, allReorgs, nodeHeight)
+		}
+	}
+	return allReorgs
+}

--- a/internal/erigon_node/deep_reorg.go
+++ b/internal/erigon_node/deep_reorg.go
@@ -42,6 +42,13 @@ func (c *NodeClient) FindDeepReorgs(ctx context.Context,
 			fmt.Fprintf(writer, "%v\n", err)
 		}
 	}
+
+	for height, reorgLengthMap := range wrongBlocks {
+		for length, count := range reorgLengthMap {
+			fmt.Fprintf(writer, "Block height: %d, length of reorg: %d, count of deep reorgs: %d \n", height, length, count)
+		}
+	}
+
 	fmt.Fprintf(writer, "Reorg iterator: %d, total scanned %s\n", total, time.Since(start))
 	fmt.Fprintf(writer, "Reorg iterator: %d, wrong blocks\n", len(wrongBlocks))
 }
@@ -142,7 +149,14 @@ func (c *NodeClient) findDeepReorgsInternally(ctx context.Context,
 			}
 		}
 	}
-	return countBlocks, allReorgs, nil
+
+	var errors []error
+	/* for height, reorgLengthMap := range allReorgs {
+		for length, count := range reorgLengthMap {
+			// flush your data from here to your respective template, A blank template has been added named deep_reorg.html
+		}
+	} */
+	return countBlocks, allReorgs, errors
 }
 
 // function to be called upon finding reorgs to store number of reorgs on that height corresponding to that reorg height

--- a/internal/erigon_node/erigon_client.go
+++ b/internal/erigon_node/erigon_client.go
@@ -189,6 +189,7 @@ type Client interface {
 	BodiesDownload(ctx context.Context, w http.ResponseWriter, template *template.Template, requestChannel chan *internal.NodeRequest)
 	HeadersDownload(ctx context.Context, w http.ResponseWriter, template *template.Template, requestChannel chan *internal.NodeRequest)
 	FindReorgs(ctx context.Context, w http.ResponseWriter, template *template.Template, requestChannel chan *internal.NodeRequest)
+	FindDeepReorgs(ctx context.Context, w http.ResponseWriter, template *template.Template, requestChannel chan *internal.NodeRequest)
 	ProcessLogList(w http.ResponseWriter, template *template.Template, sessionName string, requestChannel chan *internal.NodeRequest)
 	LogHead(filename string, requestChannel chan *internal.NodeRequest) LogPart
 	LogTail(filename string, offset uint64, requestChannel chan *internal.NodeRequest) LogPart

--- a/internal/erigon_node/remote_db_test.go
+++ b/internal/erigon_node/remote_db_test.go
@@ -61,6 +61,11 @@ func (ra *mockNodeClientReader) FindReorgs(ctx context.Context, w http.ResponseW
 	panic("implement me")
 }
 
+func (ra *mockNodeClientReader) FindDeepReorgs(ctx context.Context, w http.ResponseWriter, template *template.Template, requestChannel chan *internal.NodeRequest) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (ra *mockNodeClientReader) ProcessLogList(w http.ResponseWriter, template *template.Template, sessionName string, requestChannel chan *internal.NodeRequest) {
 	//TODO implement me
 	panic("implement me")


### PR DESCRIPTION
## Enhanced Reorg Scanner: DAG-Based Approach for Deep Reorg
### Key Improvements:
- **Deep Reorg Tracking**: The updated scanner now identifies and tracks deep reorg events, beyond the reorgs at the same blockchain height.
- **Comprehensive Data Extraction** : Scanner reads each block's hash, parent hash, and hashes of blocks at the same height to identify deep reorgs. These are complex reorg scenarios involving a fork followed by subsequent reorganizations.
- **DAG Structure Implementation** : The Directed Acyclic Graph (DAG) data structure has been adopted for visualizing the interdependencies of reorg events. Nodes in the graph represent blocks, with directed edges indicating the parent-child relationships.
- **Mapping Model**: A mapping model has been implemented, linking the parent block to the child node where the reorg occurred, along with the length of the reorg chain.

Note : Introduced a new endpoint for deep reorg : `ui/deepReorg`
API response model : 
```
{
    totalblocks : <total number of blocks scanned>,
    wrongBlocks: <mapping of block height to length of reorg to number of reorgs>
    errors: <array of errors>
}
```
API response example : 
```
{
    totalblocks : 12323,
    wrongBlocks: {
        7: {
             2: 1,
             1:1
         },
         1789: {
             2: 3,
             1:2
         },
     },
     errors: []
}
```

The API response also gives visualisation capabilities for deep reorgs in the blockchain on front-end

### Note:
To display the details of deep reorg, a template is needed where the needed data will be flushed. It can be done via `findDeepReorgsInternally` method or in functions calling it.(One can use the template provided for deep reorgs after embedding it).