### PR TITLE
Fix ws

### DIFF
--- a/api/main_handler.go
+++ b/api/main_handler.go
@@ -40,6 +40,7 @@ func NewHandler(services APIServices) http.Handler {
 		"allocs",
 		"block",
 		"mutex",
+		"txpool",
 		"admin",
 	}
 

--- a/api/websocket_handler.go
+++ b/api/websocket_handler.go
@@ -33,7 +33,7 @@ type WebsocketHandler struct {
 // **NewWebsocketHandler initializes WebsocketHandler**
 func NewWebsocketHandler(conn *websocket.Conn) *WebsocketHandler {
 	handler := &WebsocketHandler{
-		writeQueue: make(chan []byte, 100),
+		writeQueue: make(chan []byte, 200),
 		conn:       conn,
 		closeChan:  make(chan struct{}),
 		closed:     false,

--- a/api/websocket_handler.go
+++ b/api/websocket_handler.go
@@ -151,8 +151,17 @@ func (h *APIHandler) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	for {
+
 		_, msg, err := conn.ReadMessage()
 		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+				fmt.Println("Client closed connection")
+				break
+			} else if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
+				fmt.Println("Client closed connection unexpectedly")
+				break
+			}
+
 			fmt.Println("Error reading message:", err)
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	github.com/erigontech/erigonwatch v0.1.24
+	github.com/erigontech/erigonwatch v0.1.25
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	github.com/erigontech/erigonwatch v0.1.25
+	github.com/erigontech/erigonwatch v0.1.26
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/erigontech/erigonwatch v0.1.24 h1:o0Smm0IUg8Ak8sfo0BKht/jos8N9ht8wwqXJ13F5H0k=
-github.com/erigontech/erigonwatch v0.1.24/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
+github.com/erigontech/erigonwatch v0.1.25 h1:NRCwI6Np4XHVoL/vfPoFH9cphqIAAtWkXArN+is5Cjs=
+github.com/erigontech/erigonwatch v0.1.25/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/erigontech/erigonwatch v0.1.25 h1:NRCwI6Np4XHVoL/vfPoFH9cphqIAAtWkXArN+is5Cjs=
-github.com/erigontech/erigonwatch v0.1.25/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
+github.com/erigontech/erigonwatch v0.1.26 h1:6ZeB34SDFyTK3UDz+1tiVFUNyJNu9bJCB+xX413W6oY=
+github.com/erigontech/erigonwatch v0.1.26/go.mod h1:8vQ+VjvLu2gkPs8EwdPrOTAAo++WuLuBi54N7NuAF0I=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=


### PR DESCRIPTION
This pull request includes several updates to the WebSocket handling in the `api/websocket_handler.go` file and a minor dependency update in the `go.mod` file. The most important changes focus on improving the WebSocket connection management and handling.

Improvements to WebSocket handling:

* [`api/websocket_handler.go`](diffhunk://#diff-d5437b0d28232c2934927fcdf5dfcea87115ba4e4027a87ac0e6cd7124831056R30-R39): Added a `closed` field to the `WebsocketHandler` struct to track the connection state and prevent multiple closures.
* [`api/websocket_handler.go`](diffhunk://#diff-d5437b0d28232c2934927fcdf5dfcea87115ba4e4027a87ac0e6cd7124831056R84-R91): Updated the `closeConnection` method to use a mutex lock for thread-safe operation and to check if the connection is already closed before proceeding.
* [`api/websocket_handler.go`](diffhunk://#diff-d5437b0d28232c2934927fcdf5dfcea87115ba4e4027a87ac0e6cd7124831056R124-R131): Modified the `HandleWebSocket` method to close the connection gracefully when the request context is done or the channel is closed.
* [`api/websocket_handler.go`](diffhunk://#diff-d5437b0d28232c2934927fcdf5dfcea87115ba4e4027a87ac0e6cd7124831056R174-R181): Added error handling for normal and unexpected WebSocket closures in the message reading loop.

Dependency update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L20-R20): Updated the `erigontech/erigonwatch` dependency from version `v0.1.24` to `v0.1.26`.